### PR TITLE
Expose Container's new aws_instance_id field

### DIFF
--- a/lib/aptible/api/container.rb
+++ b/lib/aptible/api/container.rb
@@ -12,6 +12,7 @@ module Aptible
       field :updated_at, type: Time
       field :billforward_usage_session_id
       field :layer
+      field :aws_instance_id
     end
   end
 end

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '0.7.12'
+    VERSION = '0.7.13'
   end
 end


### PR DESCRIPTION
This PR depends on https://github.com/aptible/api.aptible.com/pull/162 which adds this field to Container.