### PR TITLE
Exposing Database's docker_repo attribute.

### DIFF
--- a/lib/aptible/api/database.rb
+++ b/lib/aptible/api/database.rb
@@ -15,6 +15,7 @@ module Aptible
       field :created_at, type: Time
       field :updated_at, type: Time
       field :status
+      field :docker_repo
 
       def failed?
         # TODO: Add failed status at API level

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '0.7.16'
+    VERSION = '0.7.17'
   end
 end


### PR DESCRIPTION
If set, this pins a database to a particular docker repo. If unset, any docker repo appropriate to the database type can be used to provision, clone, or restart.