### PR TITLE
fix typo(?) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ token = Aptible::Auth::Token.create(email: 'user0@example.com', password: 'passw
 From here, you can interact with the API however you wish:
 
 ```ruby
-api = Aptible::Api.new(token: token)
-account = api.accounts.first
+account = Aptible::Api::Account.new(token: token)
 account.apps.count
 # => 4
 account.apps.first.handle


### PR DESCRIPTION
I don't have a master account for our organization, but with the current steps I get:

api = Aptible::Api.new(token: token)
*** NoMethodError Exception: undefined method `new' for Aptible::Api:Module