### PR TITLE
Exposing GentlemanJerry fields on LogDrain

### DIFF
--- a/lib/aptible/api/log_drain.rb
+++ b/lib/aptible/api/log_drain.rb
@@ -14,6 +14,10 @@ module Aptible
       field :created_at, type: Time
       field :updated_at, type: Time
       field :status
+      field :gentlemanjerry_endpoint
+      field :gentlemanjerry_certificate
+      field :gentlemanjerry_docker_name
+      field :gentlemanjerry_instance_id
     end
   end
 end


### PR DESCRIPTION
These changes expose the GentlemanJerry fields exposed in https://github.com/aptible/api.aptible.com/pull/254.