### PR TITLE
`--initialize-from` support

### DIFF
--- a/lib/aptible/api/database.rb
+++ b/lib/aptible/api/database.rb
@@ -5,8 +5,10 @@ module Aptible
       embeds_one :last_operation
       embeds_one :disk
       has_one :service
+      has_one :initialize_from
       has_many :operations
       has_many :backups
+      has_many :dependents
 
       field :id
       field :handle

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '0.9.0'
+    VERSION = '0.9.1'
   end
 end


### PR DESCRIPTION
This is part of a set of PRs that adds support for `--initialize-from` in databases (https://github.com/aptible/sweetness/pull/509).

These changes ensure that `initialize_from` is set to nil even if it's not present for the particular database we're looking at.

---

cc @fancyremarker @aaw @blakepettersson 