### PR TITLE
Remove columns that no longer exist

### DIFF
--- a/lib/aptible/api/vhost.rb
+++ b/lib/aptible/api/vhost.rb
@@ -7,8 +7,6 @@ module Aptible
 
       field :id
       field :virtual_domain
-      field :certificate_body
-      field :private_key
       field :type
       field :elastic_load_balancer_name
       field :external_host


### PR DESCRIPTION
We no longer have `certificate_body` and `private_key` since they're now
set on the certificate object.