### PR TITLE
Add app release model

### DIFF
--- a/lib/aptible/api/app.rb
+++ b/lib/aptible/api/app.rb
@@ -3,9 +3,11 @@ module Aptible
     class App < Resource
       belongs_to :account
       belongs_to :current_configuration
+      belongs_to :current_app_release
       embeds_one :current_image
       embeds_one :last_operation
       embeds_one :last_deploy_operation
+      has_many :app_releases
       has_many :configurations
       has_many :images
       has_many :operations

--- a/lib/aptible/api/app_release.rb
+++ b/lib/aptible/api/app_release.rb
@@ -1,0 +1,10 @@
+module Aptible
+  module Api
+    class AppRelease < Resource
+      has_many :releases
+      belongs_to :app
+      field :created_at, type: Time
+      field :updated_at, type: Time
+    end
+  end
+end

--- a/lib/aptible/api/release.rb
+++ b/lib/aptible/api/release.rb
@@ -2,6 +2,7 @@ module Aptible
   module Api
     class Release < Resource
       belongs_to :service
+      embeds_one :app_release
       has_many :containers
 
       field :id

--- a/lib/aptible/api/resource.rb
+++ b/lib/aptible/api/resource.rb
@@ -16,6 +16,7 @@ end
 
 require 'aptible/api/account'
 require 'aptible/api/app'
+require 'aptible/api/app_release'
 require 'aptible/api/backup'
 require 'aptible/api/certificate'
 require 'aptible/api/configuration'


### PR DESCRIPTION
This will initially be used to determine if a set of releases
corresponds to the same deploy.

Relates to aptible/api.aptible.com#429
