### PR TITLE
Operation#with_ssh_cmd: Set IdentitiesOnly=yes

### DIFF
--- a/lib/aptible/api/operation.rb
+++ b/lib/aptible/api/operation.rb
@@ -61,8 +61,10 @@ module Aptible
           cmd = [
             'ssh',
             "#{connection.ssh_user}@#{account.bastion_host}",
-            '-p', account.ssh_portal_port.to_s
-          ] + ['-i', id_file]
+            '-p', account.ssh_portal_port.to_s,
+            '-i', id_file,
+            '-o', 'IdentitiesOnly=yes'
+          ]
 
           # If we aren't allowed to create a pty, then we shouldn't try to
           # allocate once, or we'll get an awkward error.

--- a/spec/aptible/api/operation_spec.rb
+++ b/spec/aptible/api/operation_spec.rb
@@ -66,8 +66,12 @@ describe Aptible::Api::Operation do
           if ssh_pty
             expect(cmd).not_to include('-T')
           else
-            expect(cmd.last).to eq('-T')
+            expect(cmd).to include('-T')
           end
+
+          identities_only = 'IdentitiesOnly=yes'
+          expect(cmd).to include(identities_only)
+          expect(cmd[cmd.index(identities_only) - 1]).to eq('-o')
 
           has_yielded = true
         end


### PR DESCRIPTION
This ensures that we use the private key passed via the command line
even if e.g. a SSH agent is present.

---

cc @fancyremarker 