### PR TITLE
Add discoverable field

### DIFF
--- a/lib/aptible/api/database_image.rb
+++ b/lib/aptible/api/database_image.rb
@@ -9,6 +9,7 @@ module Aptible
       field :docker_repo
       field :visible, type: Aptible::Resource::Boolean
       field :default, type: Aptible::Resource::Boolean
+      field :discoverable, type: Aptible::Resource::Boolean
       field :created_at, type: Time
       field :updated_at, type: Time
     end


### PR DESCRIPTION
This field will be used to determine whether a specific database image
actually implements the discovery API instead of having it within
Sweetness as today.

cc @krallin @fancyremarker 