### PR TITLE
Add missing tmpdir require

### DIFF
--- a/lib/aptible/api.rb
+++ b/lib/aptible/api.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 require 'aptible/auth'
 require 'gem_config'
 


### PR DESCRIPTION
It's a little unclear why this is only an issue when running in a Gem
context (and even then, not always), but since we're using
`Dir.mktmpdir`, we should be requiring `tmpdir`.