### PR TITLE
Removes unnecessary dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'pry', github: 'fancyremarker/pry', branch: 'aptible'
-gem 'activesupport', '~> 4.0'
-
 # Specify your gem's dependencies in aptible-api.gemspec
 gemspec

--- a/aptible-api.gemspec
+++ b/aptible-api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aptible-auth', '~> 1.0'
   spec.add_dependency 'gem_config'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3', '< 3.0'
   spec.add_development_dependency 'aptible-tasks', '>= 0.2.0'
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'rake', '~> 10.5'

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.1.1'.freeze
   end
 end


### PR DESCRIPTION
This change simply removes dependencies specified in the Gemfile,
rather than the gemspec (which seem to have been intended for
development purpose) and allows more versions of bundler to work.

The most important part is the removal of the dependency on
activesupport version 4. The libraries that this one depends on
allow both 4 and 5 to work, and this library does not appear
to actually require activesupport at all.