### PR TITLE
Add ability to find deleted database records from backups

### DIFF
--- a/lib/aptible/api/backup.rb
+++ b/lib/aptible/api/backup.rb
@@ -14,6 +14,11 @@ module Aptible
       field :aws_region
       field :created_at, type: Time
       field :updated_at, type: Time
+
+      def database_with_deleted
+        db_id = links['database'].href.split('/').last
+        Database.find(db_id, with_deleted: true, token: token, headers: headers)
+      end
     end
   end
 end

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end


### PR DESCRIPTION
Part of https://aptible.atlassian.net/browse/DP-282

Adds a method to allow looking up the record for a deleted database from
a backup. This will be used in sweetness to allow for copying backups
whose database has already been deleted.