### PR TITLE
Method on account to get orphaned backups.

### DIFF
--- a/lib/aptible/api/account.rb
+++ b/lib/aptible/api/account.rb
@@ -61,6 +61,14 @@ module Aptible
         rand = ('a'..'z').to_a.sample(8).join
         "#{organization_name.parameterize}-#{plan_id}-#{rand}"
       end
+
+      def each_orphaned_backup
+        base_href = "#{links['backups'].base_href}?orphaned=true"
+        Backup.each_page(href: base_href, headers: headers,
+                         token: token) do |page|
+          page.each { |entry| yield entry }
+        end
+      end
     end
   end
 end

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.2.1'.freeze
+    VERSION = '1.2.2'.freeze
   end
 end


### PR DESCRIPTION
This is modeled after the work done in `define_has_many_getters` to handle many-to-many relationships here: https://github.com/aptible/aptible-resource/blob/fcc6e399f9b8da59f3a6070908cbf328e9a9358f/lib/aptible/resource/base.rb#L151-L163
I didn't want to do something as heavyweight as actually modifying the setters/getters in aptible-resource for this one use case, given how widely it's used, and the fact that they work right now. If we do this one or two more times, we should probably seriously consider just making the change in aptible-resource, though.