### PR TITLE
Restore a backup of a deprovisioned database

### DIFF
--- a/lib/aptible/api/database.rb
+++ b/lib/aptible/api/database.rb
@@ -35,6 +35,12 @@ module Aptible
       def provisioned?
         status == 'provisioned'
       end
+
+      def current_configuration_with_deleted
+        id = links['current_configuration'].href.split('/').last
+        Aptible::Api::Configuration.find(
+          id, with_deleted: true, token: token, headers: headers)
+      end
     end
   end
 end

--- a/lib/aptible/api/database.rb
+++ b/lib/aptible/api/database.rb
@@ -39,7 +39,15 @@ module Aptible
       def current_configuration_with_deleted
         id = links['current_configuration'].href.split('/').last
         Aptible::Api::Configuration.find(
-          id, with_deleted: true, token: token, headers: headers)
+          id, with_deleted: true, token: token, headers: headers
+        )
+      end
+
+      def disk_with_deleted
+        id = links['disk'].href.split('/').last
+        Aptible::Api::Disk.find(
+          id, with_deleted: true, token: token, headers: headers
+        )
       end
     end
   end

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.2.2'.freeze
+    VERSION = '1.2.3'.freeze
   end
 end


### PR DESCRIPTION
**Relevant Links (Trello, Google Docs, etc):**
https://aptible.atlassian.net/browse/DP-292

## What does this PR accomplish / fix?

Along with corresponding PRs in `sweetness`, `deploy-api`, and `aptible-integration`, this should enable customers to restore backups of deleted databases, by overriding the default scopes that prevented the relevant configurations and disks from being visible.

## Parts that particularly need to be reviewed?
- Good places to add more tests, if any
- Versioning (the change in `sweetness` requires this one to work properly)
