### PR TITLE
Update client for AMI-related models

### DIFF
--- a/lib/aptible/api/ami.rb
+++ b/lib/aptible/api/ami.rb
@@ -1,0 +1,14 @@
+module Aptible
+  module Api
+    class Ami < Resource
+      belongs_to :ami_release
+      has_many :aws_instances
+
+      field :id
+      field :ami_id
+      field :region
+      field :created_at, type: Time
+      field :updated_at, type: Time
+    end
+  end
+end

--- a/lib/aptible/api/ami.rb
+++ b/lib/aptible/api/ami.rb
@@ -2,7 +2,6 @@ module Aptible
   module Api
     class Ami < Resource
       belongs_to :ami_release
-      has_many :aws_instances
 
       field :id
       field :ami_id

--- a/lib/aptible/api/ami_release.rb
+++ b/lib/aptible/api/ami_release.rb
@@ -1,0 +1,13 @@
+module Aptible
+  module Api
+    class AmiRelease < Resource
+      embeds_many :amis
+
+      field :id
+      field :name
+      field :default, type: Aptible::Resource::Boolean
+      field :created_at, type: Time
+      field :updated_at, type: Time
+    end
+  end
+end

--- a/lib/aptible/api/ami_release.rb
+++ b/lib/aptible/api/ami_release.rb
@@ -4,8 +4,8 @@ module Aptible
       embeds_many :amis
 
       field :id
-      field :name
-      field :default, type: Aptible::Resource::Boolean
+      field :channel
+      field :current, type: Aptible::Resource::Boolean
       field :created_at, type: Time
       field :updated_at, type: Time
     end

--- a/lib/aptible/api/aws_instance.rb
+++ b/lib/aptible/api/aws_instance.rb
@@ -2,12 +2,12 @@ module Aptible
   module Api
     class AwsInstance < Resource
       belongs_to :stack
+      belongs_to :ami
       has_many :operations
       embeds_many :databases
 
       field :id
       field :instance_id
-      field :ami
       field :instance_type
       field :availability_zone
       field :name

--- a/lib/aptible/api/resource.rb
+++ b/lib/aptible/api/resource.rb
@@ -15,6 +15,8 @@ module Aptible
 end
 
 require 'aptible/api/account'
+require 'aptible/api/ami'
+require 'aptible/api/ami_release'
 require 'aptible/api/app'
 require 'aptible/api/aws_instance'
 require 'aptible/api/backup'

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.2.8'.freeze
+    VERSION = '1.2.9'.freeze
   end
 end


### PR DESCRIPTION
This adds the Ami and AmiRelease models and updates the AwsInstance to
account for its relationship with the Ami.

Needs changes from: https://github.com/aptible/deploy-api/pull/832