### PR TITLE
Add Status to AwsInstance

### DIFF
--- a/lib/aptible/api/aws_instance.rb
+++ b/lib/aptible/api/aws_instance.rb
@@ -12,6 +12,7 @@ module Aptible
       field :availability_zone
       field :name
       field :layers
+      field :status
       field :created_at, type: Time
       field :updated_at, type: Time
     end

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.2.9'.freeze
+    VERSION = '1.2.10'.freeze
   end
 end


### PR DESCRIPTION
Exposes field added in aptible/deploy-api#837

This will formalize that field. It can be accessed already by the aptible-resource default helpers so this isn't a critical update. More for documentation purposes.