### PR TITLE
APT-531 Support new fields on AwsInstance

### DIFF
--- a/lib/aptible/api/aws_instance.rb
+++ b/lib/aptible/api/aws_instance.rb
@@ -13,8 +13,10 @@ module Aptible
       field :availability_zone
       field :name
       field :status
+      field :deprovisionable, type: Aptible::Resource::Boolean
       field :created_at, type: Time
       field :updated_at, type: Time
+      field :retain_until, type: Time
 
       def stack_layers
         instance_layer_memberships.map(&:links)


### PR DESCRIPTION
Part of https://aptible.atlassian.net/browse/APT-531

Supports new fields returned in AwsInstance by https://github.com/aptible/deploy-api/pull/898