### PR TITLE
Add drained attribute to InstanceLayerMembership

### DIFF
--- a/lib/aptible/api/instance_layer_membership.rb
+++ b/lib/aptible/api/instance_layer_membership.rb
@@ -3,6 +3,8 @@ module Aptible
     class InstanceLayerMembership < Resource
       belongs_to :stack_layer
       belongs_to :aws_instance
+
+      field :drained, type: Aptible::Resource::Boolean
     end
   end
 end


### PR DESCRIPTION
Uses new attribute from https://github.com/aptible/deploy-api/pull/903

Not required for https://github.com/aptible/sweetness/pull/1319 because HyperResource will pick up the field automatically. This is there just to document it more clearly in the client.