### PR TITLE
add services property to aws_instance

### DIFF
--- a/lib/aptible/api/aws_instance.rb
+++ b/lib/aptible/api/aws_instance.rb
@@ -6,6 +6,7 @@ module Aptible
       has_many :operations
       has_many :instance_layer_memberships
       has_many :databases
+      has_many :services
 
       field :id
       field :instance_id


### PR DESCRIPTION
This change provides access to the services attached to an aws_instance which will be required for a new operation we want to create that drains an aws instance and restarts all the services attached to it.

aptible/sweetness#1358
https://github.com/aptible/deploy-api/pull/985