### PR TITLE
aws instances with deprovisionable method

### DIFF
--- a/lib/aptible/api/stack.rb
+++ b/lib/aptible/api/stack.rb
@@ -22,6 +22,22 @@ module Aptible
       def dns_layers
         stack_layers.reject! { |l| l.dns_name.blank? }
       end
+
+      # This method is necessary because we need to include a query parameter when requesting
+      # aws_instances.
+      # Copied the important bits from
+      # https://github.com/aptible/aptible-resource/blob/4708fb80a6c21013de07c2779ffc4928cee37d4e/lib/aptible/resource/base.rb#L138
+      def aws_instances_with_deprovisionable
+        get unless loaded
+
+        return unless links['aws_instances']
+
+        self.class.all(
+          href: "#{links['aws_instances'].base_href}?include_deprovisionable=true",
+          token: token,
+          headers: headers
+        )
+      end
     end
   end
 end

--- a/lib/aptible/api/stack.rb
+++ b/lib/aptible/api/stack.rb
@@ -23,8 +23,8 @@ module Aptible
         stack_layers.reject! { |l| l.dns_name.blank? }
       end
 
-      # This method is necessary because we need to include a query parameter when requesting
-      # aws_instances.
+      # This method is necessary because we need to include a query parameter
+      # when requesting aws_instances.
       # Copied the important bits from
       # https://github.com/aptible/aptible-resource/blob/4708fb80a6c21013de07c2779ffc4928cee37d4e/lib/aptible/resource/base.rb#L138
       def aws_instances_with_deprovisionable
@@ -32,8 +32,9 @@ module Aptible
 
         return unless links['aws_instances']
 
+        href = "#{links['aws_instances'].base_href}?include_deprovisionable=true"
         self.class.all(
-          href: "#{links['aws_instances'].base_href}?include_deprovisionable=true",
+          href: href,
           token: token,
           headers: headers
         )

--- a/lib/aptible/api/stack.rb
+++ b/lib/aptible/api/stack.rb
@@ -32,7 +32,8 @@ module Aptible
 
         return unless links['aws_instances']
 
-        href = "#{links['aws_instances'].base_href}?include_deprovisionable=true"
+        param = 'include_deprovisionable=true'
+        href = "#{links['aws_instances'].base_href}?#{param}"
         self.class.all(
           href: href,
           token: token,


### PR DESCRIPTION
A recent [performance regression](https://aptible-support.slack.com/archives/C022BUSK487/p1636389454012600) prompted us to add a query parameter to our `aws_instances#index` endpoint to conditionally include the `deprovisionable` attribute.

Because we use [aptible-resource](https://github.com/aptible/aptible-resource) to perform all of our HTTP requests, we needed to figure out a way to include a query parameter.  The `:has_many aws_instances` -- on its own -- does not allow us to customize the HTTP request.  Therefore, we needed to use the methods it uses under the hood to recreate an HTTP request.

I primarily copied the important bits [from here](https://github.com/aptible/aptible-resource/blob/4708fb80a6c21013de07c2779ffc4928cee37d4e/lib/aptible/resource/base.rb#L138)

Related:
- https://github.com/aptible/deploy-api/pull/992
- https://github.com/aptible/sweetness/pull/1370

Deployment:
- This PR should be deployed with `deploy-api`