### PR TITLE
feat: added organization_id to fields for stacks/accounts and logs_url to operations' links

### DIFF
--- a/lib/aptible/api/account.rb
+++ b/lib/aptible/api/account.rb
@@ -25,6 +25,7 @@ module Aptible
       field :activated, type: Aptible::Resource::Boolean
       field :syslog_host
       field :syslog_port
+      field :organization_id
       field :created_at, type: Time
       field :updated_at, type: Time
       field :gentlemanjerry_endpoint

--- a/lib/aptible/api/operation.rb
+++ b/lib/aptible/api/operation.rb
@@ -42,7 +42,7 @@ module Aptible
       end
 
       def logs_url
-        links['logs_url']
+        links['logs'].href
       end
 
       def succeeded?

--- a/lib/aptible/api/operation.rb
+++ b/lib/aptible/api/operation.rb
@@ -41,6 +41,10 @@ module Aptible
         nil
       end
 
+      def logs_url
+        links['logs_url']
+      end
+
       def succeeded?
         status == 'succeeded'
       end

--- a/lib/aptible/api/stack.rb
+++ b/lib/aptible/api/stack.rb
@@ -16,6 +16,7 @@ module Aptible
       field :ssh_host_ecdsa_public_key
       field :ssh_portal_host
       field :ssh_portal_port
+      field :organization_id
       field :created_at, type: Time
       field :updated_at, type: Time
 


### PR DESCRIPTION
This exposes `organization_id` without having to look into `organization` for sweetness deploy-api clients.

This must be merged in FIRST:

Deploy API - https://github.com/aptible/deploy-api/pull/1064

---

This has to get merged in SECOND as all three downstream PRs consume this:

Related PRs:

Sweetness: https://github.com/aptible/sweetness/pull/1461
Aptible CLI - https://github.com/aptible/aptible-cli/pull/305


