### PR TITLE
chore: added more fields from codescan results

### DIFF
--- a/lib/aptible/api/code_scan_result.rb
+++ b/lib/aptible/api/code_scan_result.rb
@@ -14,8 +14,6 @@ module Aptible
       field :git_ref
       field :git_commit
       field :languages_detected
-      field :total_repo_size_bytes
-      field :total_file_count
 
       field :created_at, type: Time
       field :updated_at, type: Time


### PR DESCRIPTION
Allows for additional data to be stored on backend. Used for debugging and display (along with better FTUX deployment and idempotence in push)

This is not in the blocking path, but is one that can optionally be done so it's clear what params are gonna be returned