### PR TITLE
chore: incremented for release

### DIFF
--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.4.0'.freeze
+    VERSION = '1.4.1'.freeze
   end
 end


### PR DESCRIPTION
preparing to release to 1.4.1 (probably should've included in parent PR)