### PR TITLE
Add hooks to App

### DIFF
--- a/lib/aptible/api/app.rb
+++ b/lib/aptible/api/app.rb
@@ -26,6 +26,7 @@ module Aptible
       field :updated_at, type: Time
       field :status
       field :deployment_method
+      field :hooks
 
       def provisioned?
         status == 'provisioned'


### PR DESCRIPTION
New field from https://github.com/aptible/deploy-api/pull/1513

Not strictly necessary since hyperdoc will add accessors to everything deploy-api returns but good to keep up to date