### PR TITLE
Relax the constraints of what gets installed

### DIFF
--- a/aptible-api.gemspec
+++ b/aptible-api.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aptible-auth', '~> 1.0'
-  spec.add_dependency 'aptible-resource', '~> 1.0'
+  spec.add_dependency 'aptible-auth'
+  spec.add_dependency 'aptible-resource'
   spec.add_dependency 'gem_config'
   spec.add_dependency 'multipart-post', '<2.2.0'
 

--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.6.1'.freeze
+    VERSION = '1.6.2'.freeze
   end
 end


### PR DESCRIPTION
When installing both auth-api and deploy-api, it's currently impossible to use the latest of both because of version conflicts.