### PR TITLE
Add shared field to vhost

### DIFF
--- a/lib/aptible/api/version.rb
+++ b/lib/aptible/api/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Api
-    VERSION = '1.7'.freeze
+    VERSION = '1.7.1'.freeze
   end
 end

--- a/lib/aptible/api/vhost.rb
+++ b/lib/aptible/api/vhost.rb
@@ -29,6 +29,7 @@ module Aptible
       field :ip_whitelist
       field :acme_dns_challenge_host
       field :token_header
+      field :shared
 
       def account
         service.account


### PR DESCRIPTION
Needed so that sweetness can read this field on Vhosts.

https://github.com/aptible/deploy-api/pull/1715 adds the field to the model in deploy-api.